### PR TITLE
chore: Add exclude for declarations that live in the __tests__ directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "test:watch": "yarn test --watch",
         "build": "npm-run-all --parallel build:declarations build:transpile",
         "build:declarations": "tsc --p ./tsconfig.build.json",
-        "build:transpile": "babel src --ignore **/*.spec.ts --out-dir lib/cjs --extensions \".ts,.tsx\"",
+        "build:transpile": "babel src --ignore **/*.spec.ts,**/__tests__/**/* --out-dir lib/cjs --extensions \".ts,.tsx\"",
         "tsc": "tsc",
         "test:ci": "yarn test --ci",
         "validate": "npm-run-all --parallel check:static test:ci"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "jsnext:main": "lib/esm/index.js",
     "browser": "dist/brite-rest.js",
     "types": "lib/cjs/index.d.ts",
+    "files": [
+        "lib"
+    ],
     "keywords": [
         "rest",
         "api",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -7,6 +7,7 @@
         "noEmit": false
     },
     "exclude": [
+        "**/__tests__/**/*",
         "**/*.spec.ts"
     ]
 }


### PR DESCRIPTION
Locally I was getting an error about private interfaces on the utils files in the tests