### PR TITLE
chore(docs): Add contributing and pr/issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,30 @@
+<!--- Provide a general summary of the issue in the Title above -->
+
+## Current Behavior
+<!--- If describing a bug, tell us what is broken -->
+<!--- If suggesting a change/improvement tell us what is missing from the SDK as it is currently -->
+
+## Expected Behavior
+<!--- If describing a bug, tell us how the SDK should behave without the bug -->
+<!--- If you're suggesting changes, outline your idea here -->
+
+## Possible Solution
+<!--- Optional, but helpful! Use this field to suggest bug solutions or change impementation details. Feel free to get technical. -->
+
+## Steps to Reproduce (for bugs)
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code to reproduce, if relevant -->
+* Link to your project or codepen:
+1.
+2.
+3.
+4.
+
+## Screenshots (if appropriate):
+
+## Your Environment
+<!--- Please include any relevant environmental information here. (SDK version, node version, browser etc.) -->
+* SDK version:
+* Node version:
+* Browser name and version:
+* Operating system:

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -14,11 +14,6 @@
 ## Steps to Reproduce (for bugs)
 <!--- Provide a link to a live example, or an unambiguous set of steps to -->
 <!--- reproduce this bug. Include code to reproduce, if relevant -->
-* Link to your project or codepen:
-1.
-2.
-3.
-4.
 
 ## Screenshots (if appropriate):
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,5 +1,6 @@
 <!--- Provide a general summary of the issue in the Title above -->
-
+<!--- Format your PR title as such: <type>(<scope>): <subject> -->
+<!--- according to [these guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines) -->
 ## Current Behavior
 <!--- If describing a bug, tell us what is broken -->
 <!--- If suggesting a change/improvement tell us what is missing from the SDK as it is currently -->
@@ -9,7 +10,7 @@
 <!--- If you're suggesting changes, outline your idea here -->
 
 ## Possible Solution
-<!--- Optional, but helpful! Use this field to suggest bug solutions or change impementation details. Feel free to get technical. -->
+<!--- Use this field to suggest bug solutions or change impementation details. Feel free to get technical. Optional, but helpful! -->
 
 ## Steps to Reproduce (for bugs)
 <!--- Provide a link to a live example, or an unambiguous set of steps to -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,10 +2,14 @@
 
 ## Description
 <!--- Describe your changes in detail -->
-<!--- Don't forget to note any issues here with fixes #<issue number> -->
+<!--- Please include the phrase "BREAKING CHANGE:" here if your require a major release -->
+
+<!--- Don't forget to note any issues here with "fixes #<issue number>" -->
 
 ## How Has This Been Tested?
 <!--- Please describe in detail how you tested your changes. -->
+<!--- For bug fixes, include regression unit tests that fail without the fix -->
+<!--- For new features, include unit tests for the new functionality -->
 
 ## Screenshots (if appropriate):
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+<!--- Provide a general summary of your changes in the Title above -->
+
+## Description
+<!--- Describe your changes in detail -->
+<!--- Don't forget to note any issues here with fixes #<issue number> -->
+
+## How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+
+## Screenshots (if appropriate):
+
+## Checklist:
+<!--- Please mark an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [ ] I have read the **CONTRIBUTING** document.
+- [ ] I have updated the documentation accordingly.
+- [ ] I have added tests to cover my changes.
+- [ ] I have run yarn validate to ensure that tests, typescript and linting are all in order.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,7 @@
 ## Checklist:
 <!--- Please mark an `x` in all the boxes that apply. -->
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-- [ ] I have read the **CONTRIBUTING** document.
+- [ ] I have read the [**CONTRIBUTING** document](../CONTRIBUTING.md).
 - [ ] I have updated the documentation accordingly.
 - [ ] I have added tests to cover my changes.
 - [ ] I have run yarn validate to ensure that tests, typescript and linting are all in order.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,25 +2,34 @@
 
 Thank you for your interest in contributing to Eventbrite's Javascript SDK!
 
-If you'd like to contribute, we strongly recommend creating or commenting on an issue regarding your ideas or changes before getting started. 
+###Table of Contents
+* [Workflow](#workflow)
+  * [Setup](#setup)
+  * [Branches](#using-branches-to-submit-changes)
+  * [Keeping up to date](#keeping-your-local-repo-up-to-date)
+* [Creating issues](#creating-issues)
+* [Working on and submitting changes](#working-on-and-submitting-changes)
+  * [Steps to submit](#steps-to-submit)
 
 ## Workflow
 
 ### Setup
+
 1. Fork the repository
 2. Clone your new forked repository to your local computer
-3. Set the eventbrite repository as your branches upstream branch
+3. Set the Eventbrite repository as your branches upstream branch
 `git remote add upstream https://github.com/eventbrite/eventbrite-sdk-javascript.git`
-4. navigate to the root directory of your newly cloned repository 
+4. Navigate to the root directory of your newly cloned repository 
 (for mac `cd /path/to/eventbrite-sdk-javascript`)
 5. `yarn install` to install local dependencies
 
 ### Using branches to submit changes
-To work on changes to the eventbrite repository, create a new branch on your local reposity. `git checkout -b <your-new-branch-name>`
-You can name your branch whatever you'd like as long as the PR title conforms with our [PR title guidelines]()
+To work on changes to the Eventbrite repository, create a new branch on your local repository. `git checkout -b <your-new-branch-name>`
+
 
 ### Keeping your local repo up to date
-To ensure your branch never gets out of sync with Eventbrite's master, ensure that you have your upstream set properly (see the Setup step)
+To ensure your branch never gets out of sync with Eventbrite's master, ensure that you have your upstream set properly (see the [Setup](#setup) step)
+
 1. `git checkout master` (you may have to stash or commit your local changes if on a new branch)
 2. `git pull upstream master`
 3. `git checkout <your-new-branch-name>`
@@ -31,23 +40,30 @@ Always try to keep your master 'clean' by only pulling changes directly from ups
 
 It is always a good idea to pull the upstream branch in to your master branch before creating a new feature branch to work from. This will minimize the chances of encountering merge conflicts.
 
-## Filing bugs
+## Creating Issues
+Create issues to File bugs, changes, and proposals.
 
-## Submitting changes
+Before opening a new issue, please [search][issues] to see if there has been previous discussion about the same feature or issue. If so, please contribute to the discussion there. 
 
-### Fixing bugs
-If you've found a bug from our issues list that you'd like to fix, please comment on the issue to let others know you'd like to work on it. 
+If nothing is found, feel free to [open a new issue][issues] and fill out the issue template to the best of your ability.
 
-While implementing your fix, please try to change as little code as possible. This helps speed up the review process and helps diminish the chance of additional bugs. 
+## Working on and submitting changes
+When starting on improvements or new features that are non-trivial, it is always a good idea to first discuss the changes you wish to implement by [opening a github issue][issues] before getting started. 
 
-Once your fix is done, please make sure that your changes are fully covered by one or more unit tests.
+If you've found a bug or feature you'd like to work on in our [github issue tracker][issues], please comment on the issue to let others know that you'd like to work on it.
 
-Please check to make sure that your changes are documented properly (inline comments for interesting lines, READMEs, etc.)
+While implementing fixes, please try to change as little code as possible. This helps speed up the review process and helps diminish the chance of additional bugs. 
 
-Please run `yarn validate` to ensure that all of the tests pass, the code is linted and that your changes are typescript compliant. 
+Please try to conform to the coding style of the code base.
 
-Finally, please submit a pull request, noting the bug issue that you are resolving in the 'Description' section of your github pull request. 
+###Steps to submit:
 
-### Submitting features or improvements
-If you'd like to submit changes to the SDK that are non trivial, please first discuss the changes you wish to implement in our github issue tracker [here](https://github.com/eventbrite/eventbrite-sdk-javascript/issues). 
+1. Please ensure that your changes are fully covered by one or more unit test/s.
+2. Check to make sure that your changes are documented properly (inline comments for interesting lines, READMEs, etc.)
+3. Run `yarn validate` to ensure that all tests pass, the linter is satisfied and your changes are typescript compliant.
+4. PR titles must be prefixed by the type of changes the PR contains followed by the scope of what the pr touches. Please use one of `feat, fix, docs, style, refactor, perf, test, chore` as the prefix. The scope is the the direct product your changes affect. Example: `chore(build): Add encrypted ssh key for semantic-release` because its a chore and it touches the build. 
+  * For multiple scope items, you can comma separate 2 or 3 but if there are more than that please use a `*` instead.
+5. Please use a [closing issue keyword](https://help.github.com/articles/closing-issues-using-keywords/) to indicate the issue that your fix addresses in the description section of the pull request template. Example: `fixes #32` to close issue #32
 
+
+[issues]: https://github.com/eventbrite/eventbrite-sdk-javascript/issues

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,13 +15,14 @@ Thank you for your interest in contributing to Eventbrite's Javascript SDK!
 
 ### Setup
 
-1. Fork the repository
-2. Clone your new forked repository to your local computer
-3. Set the Eventbrite repository as your branches upstream branch
+1. This project uses [yarn](https://yarnpkg.com/en/) as a package management system. If you don't have it installed, you can follow the instructions [here](https://yarnpkg.com/lang/en/docs/install/)
+1. Fork the repository. [need help?](https://help.github.com/articles/fork-a-repo/)
+1. Clone your new forked repository to your local computer
+1. Set the Eventbrite repository as your branches upstream branch
 `git remote add upstream https://github.com/eventbrite/eventbrite-sdk-javascript.git`
-4. Navigate to the root directory of your newly cloned repository 
+1. Navigate to the root directory of your newly cloned repository 
 (for mac `cd /path/to/eventbrite-sdk-javascript`)
-5. `yarn install` to install local dependencies
+1. `yarn install` to install local dependencies
 
 ### Using branches to submit changes
 To work on changes to the Eventbrite repository, create a new branch on your local repository. `git checkout -b <your-new-branch-name>`
@@ -30,18 +31,18 @@ To work on changes to the Eventbrite repository, create a new branch on your loc
 ### Keeping your local repo up to date
 To ensure your branch never gets out of sync with Eventbrite's master, ensure that you have your upstream set properly (see the [Setup](#setup) step)
 
-1. `git checkout master` (you may have to stash or commit your local changes if on a new branch)
-2. `git pull upstream master`
-3. `git checkout <your-new-branch-name>`
-4. `git rebase master`
-5. If you've stashed changes, unstash them now, otherwise your branch should now be up to date
+1. `git checkout master` (you may have to [stash or commit][stash-docs] your local changes if on a new branch)
+1. `git pull upstream master`
+1. `git checkout <your-new-branch-name>`
+1. `git rebase master`
+1. If you've stashed changes, [unstash][stash-docs] them now, otherwise your branch should now be up to date
 
 Always try to keep your master 'clean' by only pulling changes directly from upstream into your master branch and rebasing those changes onto your working branch.
 
 It is always a good idea to pull the upstream branch in to your master branch before creating a new feature branch to work from. This will minimize the chances of encountering merge conflicts.
 
 ## Creating Issues
-Create issues to File bugs, changes, and proposals.
+Create issues to file bugs, changes, and proposals.
 
 Before opening a new issue, please [search][issues] to see if there has been previous discussion about the same feature or issue. If so, please contribute to the discussion there. 
 
@@ -58,12 +59,13 @@ Please try to conform to the coding style of the code base.
 
 ###Steps to submit:
 
-1. Please ensure that your changes are fully covered by one or more unit test/s.
-2. Check to make sure that your changes are documented properly (inline comments for interesting lines, READMEs, etc.)
-3. Run `yarn validate` to ensure that all tests pass, the linter is satisfied and your changes are typescript compliant.
-4. PR titles must be prefixed by the type of changes the PR contains followed by the scope of what the pr touches. Please use one of `feat, fix, docs, style, refactor, perf, test, chore` as the prefix. The scope is the the direct product your changes affect. Example: `chore(build): Add encrypted ssh key for semantic-release` because its a chore and it touches the build. 
+1. Please ensure that your changes are fully covered by one or more unit test(s).
+1. Check to make sure that your changes are documented properly (inline comments for interesting lines, READMEs, etc.)
+1. Run `yarn validate` to ensure that all tests pass, the linter is satisfied and your changes are typescript compliant.
+1. PR titles must be prefixed by the type of changes the PR contains followed by the scope of what the pr touches. We are following the [angular commit guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines). Please use one of `feat, fix, docs, style, refactor, perf, test, chore` as the prefix. The scope is the the direct product your changes affect. Example: `chore(build): Add encrypted ssh key for semantic-release` because its a chore and it touches the build. 
   * For multiple scope items, you can comma separate 2 or 3 but if there are more than that please use a `*` instead.
-5. Please use a [closing issue keyword](https://help.github.com/articles/closing-issues-using-keywords/) to indicate the issue that your fix addresses in the description section of the pull request template. Example: `fixes #32` to close issue #32
+1. Please use a [closing issue keyword](https://help.github.com/articles/closing-issues-using-keywords/) to indicate the issue that your fix addresses in the description section of the pull request template. Example: `fixes #32` to close issue #32
 
 
 [issues]: https://github.com/eventbrite/eventbrite-sdk-javascript/issues
+[stash-docs]: https://git-scm.com/book/en/v1/Git-Tools-Stashing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,53 @@
+#Contributing
+
+Thank you for your interest in contributing to Eventbrite's Javascript SDK!
+
+If you'd like to contribute, we strongly recommend creating or commenting on an issue regarding your ideas or changes before getting started. 
+
+## Workflow
+
+### Setup
+1. Fork the repository
+2. Clone your new forked repository to your local computer
+3. Set the eventbrite repository as your branches upstream branch
+`git remote add upstream https://github.com/eventbrite/eventbrite-sdk-javascript.git`
+4. navigate to the root directory of your newly cloned repository 
+(for mac `cd /path/to/eventbrite-sdk-javascript`)
+5. `yarn install` to install local dependencies
+
+### Using branches to submit changes
+To work on changes to the eventbrite repository, create a new branch on your local reposity. `git checkout -b <your-new-branch-name>`
+You can name your branch whatever you'd like as long as the PR title conforms with our [PR title guidelines]()
+
+### Keeping your local repo up to date
+To ensure your branch never gets out of sync with Eventbrite's master, ensure that you have your upstream set properly (see the Setup step)
+1. `git checkout master` (you may have to stash or commit your local changes if on a new branch)
+2. `git pull upstream master`
+3. `git checkout <your-new-branch-name>`
+4. `git rebase master`
+5. If you've stashed changes, unstash them now, otherwise your branch should now be up to date
+
+Always try to keep your master 'clean' by only pulling changes directly from upstream into your master branch and rebasing those changes onto your working branch.
+
+It is always a good idea to pull the upstream branch in to your master branch before creating a new feature branch to work from. This will minimize the chances of encountering merge conflicts.
+
+## Filing bugs
+
+## Submitting changes
+
+### Fixing bugs
+If you've found a bug from our issues list that you'd like to fix, please comment on the issue to let others know you'd like to work on it. 
+
+While implementing your fix, please try to change as little code as possible. This helps speed up the review process and helps diminish the chance of additional bugs. 
+
+Once your fix is done, please make sure that your changes are fully covered by one or more unit tests.
+
+Please check to make sure that your changes are documented properly (inline comments for interesting lines, READMEs, etc.)
+
+Please run `yarn validate` to ensure that all of the tests pass, the code is linted and that your changes are typescript compliant. 
+
+Finally, please submit a pull request, noting the bug issue that you are resolving in the 'Description' section of your github pull request. 
+
+### Submitting features or improvements
+If you'd like to submit changes to the SDK that are non trivial, please first discuss the changes you wish to implement in our github issue tracker [here](https://github.com/eventbrite/eventbrite-sdk-javascript/issues). 
+

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Read more on [getting a token](https://www.eventbrite.com/developer/v3/api_overv
 
 ## Contributing
 
-Check out our contributing document [here](https://github.com/eventbrite/eventbrite-sdk-javascript/blob/master/CONTRIBUTING.md)
+Contributions are welcome! See [Contributing Guidelines](CONTRIBUTING.md) for more details.
 
 ## Project philosophy
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Read more on [getting a token](https://www.eventbrite.com/developer/v3/api_overv
 
 ## Contributing
 
-Coming soon...
+Check out our contributing document [here](https://github.com/eventbrite/eventbrite-sdk-javascript/blob/master/CONTRIBUTING.md)
 
 ## Project philosophy
 


### PR DESCRIPTION
First pass at writing contributing docs and the issue/pr templates! Looking for feedback on clarity rewrites, topics to add and template information. 

This pr adds a contributing doc outline what is expected of a developer looking to contribute.
Also included are two template MD files that outline information we'd like to see in our submitted issues and prs. 

Let me know what you think!

fixes #16 