### PR TITLE
chore(build): Add semantic-release in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,13 @@ node_js:
 # Run the the validate script
 script: yarn run validate
 
+# We of course run a build first to generate the build targets
+before_deploy: yarn run build
+
 # Using semantic-release, deploy a new version of the library
 # We're running multiple node jobs so travis-deploy-once ensures
-# that it only tries to deploy once. We of course run a build first
-# to release the build targets
+# that it only tries to deploy once.
 deploy:
   provider: script
   skip_cleanup: true
-  script:
-    - yarn run build
-    - npx travis-deploy-once "npx semantic-release"
+  script: npx travis-deploy-once "npx semantic-release"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,4 @@ before_deploy: yarn run build
 # that it only tries to deploy once.
 deploy:
   provider: script
-  skip_cleanup: true
   script: npx travis-deploy-once "npx semantic-release"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,20 @@
 language: node_js
 node_js:
   - "node"
+  - "10"
   - "8"
   - "6"
 
-# Cache dependencies in $HOME/.yarn-cache across builds
-cache: yarn
 # Run the the validate script
-# Temporarily also run the build script to make sure it works
-# (will move this to the release step once that's implemented)
-script: yarn run validate --ci && yarn run build
+script: yarn run validate
 
+# Using semantic-release, deploy a new version of the library
+# We're running multiple node jobs so travis-deploy-once ensures
+# that it only tries to deploy once. We of course run a build first
+# to release the build targets
+deploy:
+  provider: script
+  skip_cleanup: true
+  script:
+    - yarn run build
+    - npx travis-deploy-once "npx semantic-release"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![downloads](https://img.shields.io/npm/dt/eventbrite.svg)](http://npm-stat.com/charts.html?package=eventbrite&from=2018-05-01)
 [![module formats: esm, cjs, & umd](https://img.shields.io/badge/module%20formats-esm%2C%20cjs%2C%20umd-green.svg)](https://unkpg.com/eventbrite/)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
+[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](http://makeapullrequest.com)
 [![license](https://img.shields.io/github/license/eventbrite/eventbrite-sdk-javascript.svg)](LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 [![version](https://img.shields.io/npm/v/eventbrite.svg)](http://npm.im/eventbrite)
 [![downloads](https://img.shields.io/npm/dt/eventbrite.svg)](http://npm-stat.com/charts.html?package=eventbrite&from=2018-05-01)
 [![module formats: esm, cjs, & umd](https://img.shields.io/badge/module%20formats-esm%2C%20cjs%2C%20umd-green.svg)](https://unkpg.com/eventbrite/)
+![npm type definitions](https://img.shields.io/npm/types/eventbrite.svg)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
-[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
+
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](http://makeapullrequest.com)
 [![license](https://img.shields.io/github/license/eventbrite/eventbrite-sdk-javascript.svg)](LICENSE)
 
@@ -12,6 +13,8 @@
 [![Build Status](https://travis-ci.org/eventbrite/eventbrite-sdk-javascript.svg?branch=master)](https://travis-ci.org/eventbrite/eventbrite-sdk-javascript)
 [![Dependencies status](https://img.shields.io/david/eventbrite/eventbrite-sdk-javascript.svg)](https://david-dm.org/eventbrite/eventbrite-sdk-javascript)
 [![Dev Dependencies status](https://img.shields.io/david/dev/eventbrite/eventbrite-sdk-javascript.svg)](https://david-dm.org/eventbrite/eventbrite-sdk-javascript?type=dev)
+
+[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
 
 [![Watch on GitHub](https://img.shields.io/github/watchers/eventbrite/eventbrite-sdk-javascript.svg?style=social)](https://github.com/eventbrite/eventbrite-sdk-javascript/watchers)
 [![Star on GitHub](https://img.shields.io/github/stars/eventbrite/eventbrite-sdk-javascript.svg?style=social)](https://github.com/eventbrite/eventbrite-sdk-javascript/stargazers)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The official JavaScript SDK for the [Eventbrite v3 API](https://www.eventbrite.c
 
 *   [Installation](#installation)
 *   [Quick Usage](#quick-usage)
-*   [API Docs](#api-docs)
+*   [API Docs](docs/)
 *   [Target Environments](#target-environments)
 *   [Contributing](CONTRIBUTING.md)
 *   [Project philosophy](#project-philosophy)
@@ -66,9 +66,11 @@ Read more on [getting a token](https://www.eventbrite.com/developer/v3/api_overv
 
 ## API Docs
 
-Coming soon...
+[Eventbrite v3 API JavaScript SDK Documentation](docs/)
 
 ## Target Environments
+
+The SDK works in both the browser and Node environments. As a result, we provide multiple build targets for you to consume depending on your environment:
 
 ### Libraries
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 [![Watch on GitHub](https://img.shields.io/github/watchers/eventbrite/eventbrite-sdk-javascript.svg?style=social)](https://github.com/eventbrite/eventbrite-sdk-javascript/watchers)
 [![Star on GitHub](https://img.shields.io/github/stars/eventbrite/eventbrite-sdk-javascript.svg?style=social)](https://github.com/eventbrite/eventbrite-sdk-javascript/stargazers)
-[![Tweet](https://img.shields.io/twitter/url/https/github.com/eventbrite/eventbrite-sdk-javascript.svg?style=social)](https://twitter.com/intent/tweet?text=Check%20out%20eventbrite%20by%20%40evbeng!%0A%0Ahttps%3A%2F%2Fgithub.com%2Feventbrite%2Feventbrite-sdk-javascript)
+[![Tweet](https://img.shields.io/twitter/url/https/github.com/eventbrite/eventbrite-sdk-javascript.svg?style=social)](https://twitter.com/intent/tweet?text=Check%20out%20the%20official%20Eventbrite%20API%20JavaScript%20DSK%20by%20%40evbeng!%20%0A%20https%3A%2F%2Fgithub.com%2Feventbrite%2Feventbrite-sdk-javascript%2F)
 
 The official JavaScript SDK for the [Eventbrite v3 API](https://www.eventbrite.com/developer/v3/).
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,50 @@
 # Eventbrite JavaScript SDK
 
-> NOTE: This library is still in alpha and under initial development.
+[![version](https://img.shields.io/npm/v/eventbrite.svg)](http://npm.im/eventbrite)
+[![downloads](https://img.shields.io/npm/dt/eventbrite.svg)](http://npm-stat.com/charts.html?package=eventbrite&from=2018-05-01)
+[![module formats: esm, cjs, & umd](https://img.shields.io/badge/module%20formats-esm%2C%20cjs%2C%20umd-green.svg)](https://unkpg.com/eventbrite/)
+[![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](http://makeapullrequest.com)
+[![license](https://img.shields.io/github/license/eventbrite/eventbrite-sdk-javascript.svg)](LICENSE)
+
+[![Maintenance Status](https://img.shields.io/badge/status-maintained-brightgreen.svg)](https://github.com/eventbrite/eventbrite-sdk-javascript/pulse)
+[![Build Status](https://travis-ci.org/eventbrite/eventbrite-sdk-javascript.svg?branch=master)](https://travis-ci.org/eventbrite/eventbrite-sdk-javascript)
+[![Dependencies status](https://img.shields.io/david/eventbrite/eventbrite-sdk-javascript.svg)](https://david-dm.org/eventbrite/eventbrite-sdk-javascript)
+[![Dev Dependencies status](https://img.shields.io/david/dev/eventbrite/eventbrite-sdk-javascript.svg)](https://david-dm.org/eventbrite/eventbrite-sdk-javascript?type=dev)
+
+[![Watch on GitHub](https://img.shields.io/github/watchers/eventbrite/eventbrite-sdk-javascript.svg?style=social)](https://github.com/eventbrite/eventbrite-sdk-javascript/watchers)
+[![Star on GitHub](https://img.shields.io/github/stars/eventbrite/eventbrite-sdk-javascript.svg?style=social)](https://github.com/eventbrite/eventbrite-sdk-javascript/stargazers)
+[![Tweet](https://img.shields.io/twitter/url/https/github.com/eventbrite/eventbrite-sdk-javascript.svg?style=social)](https://twitter.com/intent/tweet?text=Check%20out%20eventbrite%20by%20%40evbeng!%0A%0Ahttps%3A%2F%2Fgithub.com%2Feventbrite%2Feventbrite-sdk-javascript)
+
+The official JavaScript SDK for the [Eventbrite v3 API](https://www.eventbrite.com/developer/v3/).
+
+> NOTE: This library is still in **beta** as we flesh out the API of the SDK.
+
+## ToC
+
+*   [Installation](#installation)
+*   [Quick Usage](#quick-usage)
+*   [API Docs](#api-docs)
+*   [Target Environments](#target-environments)
+*   [Contributing](CONTRIBUTING.md)
+*   [Project philosophy](#project-philosophy)
+*   [License](LICENSE)
 
 ## Installation
 
-Coming soon...
+Install via [Yarn](https://yarnpkg.com/lang/en/docs/managing-dependencies/):
 
-## Usage
+```sh
+yarn add eventbrite
+```
+
+Install via [NPM](https://docs.npmjs.com/getting-started/installing-npm-packages-locally):
+
+```sh
+npm install --save eventbrite
+```
+
+## Quick Usage
 
 ```js
 const eventbrite = require('eventbrite');
@@ -22,6 +60,25 @@ sdk.request('/users/me').then(res => {
 
 Read more on [getting a token](https://www.eventbrite.com/developer/v3/api_overview/authentication/#ebapi-getting-a-token).
 
+## API Docs
+
+Coming soon...
+
+## Target Environments
+
+### Libraries
+
+*   [**ESM**](https://unpkg.com/eventbrite/lib/esm/) - (EMCAScript modules) Everything transpiled to ES5 except for ES2015 `import`/`export` statements enabling [_tree shaking_](https://webpack.js.org/guides/tree-shaking/)
+*   [**CJS**](https://unpkg.com/eventbrite/lib/cjs/) - (CommonJS) Standard format for most bundling systems including Node fully transpiled to ES5
+*   [**UMD**](https://unpkg.com/eventbrite/lib/umd/) - (Universal module definition) Combination of EJS & AMD (asynchronous module definition) fully transpiled to ES5
+
+### Bundled distributions
+
+If you don't have or cannot use a module system in your web app, the bundle distributions come as a single file with all of the dependencies included:
+
+*   [`eventbrite.min.js`](https://unpkg.com/eventbrite/dist/eventbrite.min.js) - Minified and fully transpiled `<script>` include
+*   [`eventbrite.js`](https://unpkg.com/eventbrite/dist/eventbrite.js) - Unminified and fully transpiled `<script>` include
+
 ## Contributing
 
 Contributions are welcome! See [Contributing Guidelines](CONTRIBUTING.md) for more details.
@@ -29,6 +86,8 @@ Contributions are welcome! See [Contributing Guidelines](CONTRIBUTING.md) for mo
 ## Project philosophy
 
 We take the stability of this SDK **very** seriously. `eventbrite` follows the [SemVer](http://semver.org/) standard for versioning.
+
+All updates must pass the [CI build](https://travis-ci.org/eventbrite/eventbrite-sdk-javascript/).
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# Eventbrite JavaScript SDK Documentation
+# Eventbrite v3 API JavaScript SDK Documentation
 
 This SDK interface closely mirors the [Eventbrite v3 REST API](https://www.eventbrite.com/developer/v3/) endpoints that it wraps. The SDK provides many conveniences for making requests and processing responses to make it easier to use in the JavaScript environment.
 
@@ -6,7 +6,7 @@ This SDK interface closely mirors the [Eventbrite v3 REST API](https://www.event
 
 *   [Including the package](#including-the-package)
 *   [Configuring a SDK object](#configuring-a-sdk-object)
-*   [`request()`](./request)
+*   [`request()`](./request.md)
 
 ## Including the package
 

--- a/src/request.ts
+++ b/src/request.ts
@@ -142,7 +142,8 @@ const _catchStatusError = (res: Response): Promise<any> =>
     });
 
 /**
- * Fetch wrapper that parses v3 errors received by the API
+ * Low-level method that makes fetch requests, returning the response formatted as JSON.
+ * It parses errors from API v3 and throws exceptions with those errors
  */
 export default (url: string, options?: RequestInit): Promise<{}> =>
     _fetchJSON(url, options).catch(_catchStatusError);


### PR DESCRIPTION
## Description
Updates `.travis.yml` to have a deploy step that calls `semantic-release` with `npx`.

Also updated the `README` with a bunch of new content in anticipation of the library being released.

Lastly did some misc updates to `CONTRIBUTING.md` & `PULL_REQUEST_TEMPLATE.md`

Fixes #17 

> NOTE: This cannot be merged until we take ownership of the [eventbrite NPM package](https://www.npmjs.com/package/eventbrite)

## How Has This Been Tested?
There's no real way to test this besides actually releasing.

## Screenshots (if appropriate):

n/a

## Checklist:
<!--- Please mark an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING** document](../CONTRIBUTING.md).
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] I have run `yarn validate` to ensure that tests, typescript and linting are all in order.
