### PR TITLE
chore(build): Run semantic release on latest node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,10 @@ script: yarn run validate
 before_deploy: yarn run build
 
 # Using semantic-release, deploy a new version of the library
-# We're running multiple node jobs so travis-deploy-once ensures
-# that it only tries to deploy once.
+# We're running multiple node jobs so running on latest Node
+# version
 deploy:
   provider: script
-  script: npx travis-deploy-once "npx semantic-release"
+  script: npx semantic-release
+  on:
+    node: "node"


### PR DESCRIPTION
## Description

When running the build on Node 6, we only have NPM 3, which doesn't have `npx`. So by adding the deploy `on` filter to run `semantic-release` on the latest node version, we won't try to even run it on Node 6.

BREAKING CHANGE: We need to trigger a version bump after taking over the package. Because #33 was just a `chore()`, `semantic-release` assumed there was nothing to release.

## How Has This Been Tested?

Unfortunately cannot test w/o releasing 😔

## Screenshots (if appropriate):

n/a

## Checklist:

*   [X] I have read the [**CONTRIBUTING** document](https://github.com/eventbrite/eventbrite-sdk-javascript/blob/master/CONTRIBUTING.md).
*   [X] I have updated the documentation accordingly.
*   [X] I have added tests to cover my changes.
*   [X] I have run `yarn validate` to ensure that tests, typescript and linting are all in order.
