### PR TITLE
chore(deploy): Update deploy to use LTS node host

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ deploy:
   provider: script
   script: npx semantic-release
   on:
-    node: "node"
+    node: "10"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

After disabling the `node` host due to a build error, the release was not deployed since it was set to run on the `node` host. 

Going forward we are going to use the node LTS as our deploy host.  
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- For bug fixes, include regression unit tests that fail without the fix -->

<!--- For new features, include unit tests for the new functionality -->

## Screenshots (if appropriate):

## Checklist:

<!--- Please mark an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [x] I have read the [**CONTRIBUTING** document](https://github.com/eventbrite/eventbrite-sdk-javascript/blob/master/CONTRIBUTING.md).
*   [x] I have updated the documentation accordingly.
*   [x] I have added tests to cover my changes.
*   [x] I have run `yarn validate` to ensure that tests, typescript and linting are all in order.
