### PR TITLE
fix(request): Set GET as default request method

### DIFF
--- a/src/__tests__/request.spec.ts
+++ b/src/__tests__/request.spec.ts
@@ -58,6 +58,19 @@ describe('request', () => {
             );
         });
 
+        it('calls should not send "application/json", if method is not passed', async () => {
+            await request(TEST_URL);
+
+            expect(getMockFetch()).toHaveBeenCalledTimes(1);
+            expect(getMockFetch()).toHaveBeenCalledWith(
+                TEST_URL,
+                expect.objectContaining({
+                    credentials: 'same-origin',
+                    headers: {},
+                })
+            );
+        });
+
         it('calls fetch and respects overrides in options', async () => {
             await request(TEST_URL, {credentials: 'omit'});
 

--- a/src/request.ts
+++ b/src/request.ts
@@ -37,7 +37,7 @@ const _tryParseJSON = (res: Response): Promise<any> => {
  */
 export const _fetchJSON = (
     url: string,
-    {headers, method, mode, ...options}: RequestInit = {}
+    {headers = {}, method = 'GET', mode, ...options}: RequestInit = {}
 ): Promise<{}> => {
     let fetchHeaders = headers as HeadersInit;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
As mentioned in #49, query params were being ignored when passed in via the SDK. 

I investigated and found that this was due to our default of the `Content-Type` header. The defaulting was put in place to handle `POST` but since method is undefined it was also being set for implied `GET` requests. 

<!--- Describe your changes in detail -->

<!--- Please include the phrase "BREAKING CHANGE:" here if your require a major release -->

<!--- Don't forget to note any issues here with "fixes #<issue number>" -->

## How Has This Been Tested?
Tests have been updated. I also verified that setting get will address query params not being parsed properly on the backend. 

<!--- Please describe in detail how you tested your changes. -->

<!--- For bug fixes, include regression unit tests that fail without the fix -->

<!--- For new features, include unit tests for the new functionality -->

## Screenshots (if appropriate):

## Checklist:

<!--- Please mark an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [x] I have read the [**CONTRIBUTING** document](https://github.com/eventbrite/eventbrite-sdk-javascript/blob/master/CONTRIBUTING.md).
*   [x] I have updated the documentation accordingly.
*   [x] I have added tests to cover my changes.
*   [x] I have run `yarn validate` to ensure that tests, typescript and linting are all in order.

resolves #49