### PR TITLE
Add organizations api

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,7 +21,8 @@
         "typescript/no-array-constructor": "error",
         "typescript/no-empty-interface": "error",
         "typescript/no-use-before-define": "error",
-        "typescript/type-annotation-spacing": "error"
+        "typescript/type-annotation-spacing": "error",
+        "jest/lowercase-name": "none"
     },
     "settings": {
         "import/resolver": {

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ This SDK interface closely mirors the [Eventbrite v3 REST API](https://www.event
 -   [Configuring a SDK object](#configuring-a-sdk-object)
 -   [`request()`](./request.md)
 -   [Users](./users.md)
+-   [Organizations](./organizations.md)
 
 ## Including the package
 

--- a/docs/organizations.md
+++ b/docs/organizations.md
@@ -1,0 +1,39 @@
+# Organizations
+
+This is a collection of methods that are intended to be helpful wrappers around the [organizations API endpoints](organization-api-docs).
+
+View the [Organizations response object](organization-object-reference) for details on the properties you'll get back with each response.
+
+## Table on Contents
+
+- [`sdk.organizations.getByUser(id)`](#getByUser)
+
+<a id="getByUser"></a>
+
+## `sdk.organizations.getByUser(id)`
+Gets the details for a specific user by their user id. 
+
+**Read [`/users/:id/organizations/` documentation](organization-by-user) for more details.**
+
+### API
+```js
+sdk.organizations.getByUser(id: string): Promise<Organization>
+```
+
+### Example
+
+```js
+const eventbrite = require('eventbrite');
+
+// Create configured Eventbrite SDK
+const sdk = eventbrite({token: 'OATH_TOKEN_HERE'});
+
+sdk.organizations.getByUser('1234567890').then((organization) => {
+    console.log(`Welcome to ${organization.name}!`);
+});
+```
+
+<!-- link reference section -->
+[organization-api-docs]: https://www.eventbrite.com/platform/api#/reference/organization
+[organization-object-reference]: https://www.eventbrite.com/platform/api#/reference/organization
+[organization-by-user]: https://www.eventbrite.com/platform/api#/reference/user/retrieve-a-user

--- a/docs/organizations.md
+++ b/docs/organizations.md
@@ -13,11 +13,11 @@ View the [Organizations response object](organization-object-reference) for deta
 ## `sdk.organizations.getByUser(id)`
 Gets the details for a specific user by their user id. 
 
-**Read [`/users/:id/organizations/` documentation](organization-by-user) for more details.**
+**Read [`/users/:userId/organizations/` documentation](organization-by-user) for more details.**
 
 ### API
 ```js
-sdk.organizations.getByUser(id: string): Promise<Organization>
+sdk.organizations.getByUser(userId: string): Promise<Paginated<Organization[]>>
 ```
 
 ### Example
@@ -28,12 +28,12 @@ const eventbrite = require('eventbrite');
 // Create configured Eventbrite SDK
 const sdk = eventbrite({token: 'OATH_TOKEN_HERE'});
 
-sdk.organizations.getByUser('1234567890').then((organization) => {
-    console.log(`Welcome to ${organization.name}!`);
+sdk.organizations.getByUser('1234567890').then((paginatedResponse) => {
+    console.log(`Here are your organizations: ${paginatedResponse.organizations.join(' ')}.`);
 });
 ```
 
 <!-- link reference section -->
 [organization-api-docs]: https://www.eventbrite.com/platform/api#/reference/organization
 [organization-object-reference]: https://www.eventbrite.com/platform/api#/reference/organization
-[organization-by-user]: https://www.eventbrite.com/platform/api#/reference/user/retrieve-a-user
+[organization-by-user]: https://www.eventbrite.com/platform/api#/reference/organization/list-organizations-by-user

--- a/src/__tests__/__fixtures__/index.ts
+++ b/src/__tests__/__fixtures__/index.ts
@@ -42,3 +42,20 @@ export const MOCK_ARGUMENTS_ERROR_RESPOSNE_DATA = {
     error_description: 'There are errors with your arguments: status - INVALID',
     error: 'ARGUMENTS_ERROR',
 };
+
+export const MOCK_ORGS_BY_USER_SUCCESS_RESPONSE = {
+    organizations: [
+        {
+            id: '1',
+            name: 'Organization 1',
+        },
+        {
+            id: '2',
+            name: 'Organization 2',
+        },
+        {
+            id: '3',
+            name: 'Organization 3',
+        },
+    ],
+};

--- a/src/__tests__/__fixtures__/index.ts
+++ b/src/__tests__/__fixtures__/index.ts
@@ -44,6 +44,14 @@ export const MOCK_ARGUMENTS_ERROR_RESPOSNE_DATA = {
 };
 
 export const MOCK_ORGS_BY_USER_SUCCESS_RESPONSE = {
+    pagination: {
+        object_count: 3,
+        page_number: 1,
+        page_size: 10,
+        page_count: 1,
+        continuation: 'some_fake_continuation_key',
+        has_more_items: false,
+    },
     organizations: [
         {
             id: '1',

--- a/src/__tests__/__fixtures__/index.ts
+++ b/src/__tests__/__fixtures__/index.ts
@@ -67,3 +67,28 @@ export const MOCK_ORGS_BY_USER_SUCCESS_RESPONSE = {
         },
     ],
 };
+
+export const MOCK_TRANSFORMED_ORGS_BY_USER = {
+    pagination: {
+        objectCount: 3,
+        pageNumber: 1,
+        pageSize: 10,
+        pageCount: 1,
+        continuation: 'some_fake_continuation_key',
+        hasMoreItems: false,
+    },
+    organizations: [
+        {
+            id: '1',
+            name: 'Organization 1',
+        },
+        {
+            id: '2',
+            name: 'Organization 2',
+        },
+        {
+            id: '3',
+            name: 'Organization 3',
+        },
+    ],
+};

--- a/src/__tests__/organizations.spec.ts
+++ b/src/__tests__/organizations.spec.ts
@@ -1,0 +1,10 @@
+import {
+    mockFetch,
+    getMockFetch,
+    getMockResponse,
+    restoreMockFetch,
+} from './utils';
+import {} from './__fixtures__';
+
+import request from '../request';
+import {OrganizationsApi} from '../organizations';

--- a/src/__tests__/organizations.spec.ts
+++ b/src/__tests__/organizations.spec.ts
@@ -10,19 +10,7 @@ import {
 } from './__fixtures__';
 
 import request from '../request';
-import {OrganizationsApiorganizationsApiimport {
-    mockFetch,
-    getMockFetch,
-    getMockResponse,
-    restoreMockFetch,
-} from './utils';
-import {
-    MOCK_ORGS_BY_USER_SUCCESS_RESPONSE,
-    MOCK_TRANSFORMED_ORGS_BY_USER,
-} from './__fixtures__';
-
-import request from '../request';
-import { OrganizationsApi } from '../organizations';
+import {OrganizationsApi} from '../organizations';
 
 describe('OrganizationsApi', () => {
     describe('getByUser()', () => {

--- a/src/__tests__/organizations.spec.ts
+++ b/src/__tests__/organizations.spec.ts
@@ -4,7 +4,76 @@ import {
     getMockResponse,
     restoreMockFetch,
 } from './utils';
-import {} from './__fixtures__';
+import {
+    MOCK_ORGS_BY_USER_SUCCESS_RESPONSE,
+    MOCK_TRANSFORMED_ORGS_BY_USER,
+} from './__fixtures__';
 
 import request from '../request';
-import {OrganizationsApi} from '../organizations';
+import {OrganizationsApiorganizationsApiimport {
+    mockFetch,
+    getMockFetch,
+    getMockResponse,
+    restoreMockFetch,
+} from './utils';
+import {
+    MOCK_ORGS_BY_USER_SUCCESS_RESPONSE,
+    MOCK_TRANSFORMED_ORGS_BY_USER,
+} from './__fixtures__';
+
+import request from '../request';
+import { OrganizationsApi } from '../organizations';
+
+describe('OrganizationsApi', () => {
+    describe('getByUser()', () => {
+        it('calls fetch and calls fetch with appropriate defaults', async() => {
+            const organizations = new OrganizationsApi(request);
+
+            mockFetch(getMockResponse(MOCK_ORGS_BY_USER_SUCCESS_RESPONSE));
+
+            await expect(organizations.getByUser('fake_id')).resolves.toEqual(
+                MOCK_TRANSFORMED_ORGS_BY_USER
+            );
+
+            expect(getMockFetch()).toHaveBeenCalledTimes(1);
+            expect(getMockFetch()).toHaveBeenCalledWith(
+                '/users/fake_id/organizations/',
+                expect.objectContaining({})
+            );
+
+            restoreMockFetch();
+        });
+
+        it('handle token missing requests', async() => {
+            const organizations = new OrganizationsApi(request);
+
+            mockFetch(
+                getMockResponse(
+                    {
+                        status_code: 401,
+                        error_description:
+                            'An OAuth token is required for all requests',
+                        error: 'NO_AUTH',
+                    },
+                    {status: 401}
+                )
+            );
+
+            await expect(
+                organizations.getByUser('fake_id')
+            ).rejects.toMatchObject({
+                response: expect.objectContaining({
+                    status: 401,
+                    statusText: 'Unauthorized',
+                    ok: false,
+                }),
+                parsedError: {
+                    description: 'An OAuth token is required for all requests',
+                    error: 'NO_AUTH',
+                },
+            });
+
+            restoreMockFetch();
+        });
+    });
+});

--- a/src/organizations.ts
+++ b/src/organizations.ts
@@ -1,0 +1,35 @@
+import {BaseApi} from './baseApi';
+
+enum OrganizationVertical {
+    Default,
+    Music,
+}
+
+export interface Organization {
+    id: string;
+    name: string;
+    imageId: string;
+    locale?: string;
+    vertical?: OrganizationVertical;
+}
+
+export interface PaginatedOrganizationResponse {
+    pagination: {
+        object_count: number;
+        page_number: number;
+        page_size: number;
+        page_count: number;
+        continuation: string;
+        has_more_items: boolean;
+    };
+    organizations: Organization[];
+}
+
+/**
+ * API for working with Organizations
+ */
+export class OrganizationsApi extends BaseApi<PaginatedOrganizationResponse> {
+    getByUser(userId: string) {
+        return this.request(`/users/${userId}/organizations/`);
+    }
+}

--- a/src/organizations.ts
+++ b/src/organizations.ts
@@ -1,34 +1,18 @@
 import {BaseApi} from './baseApi';
-
-enum OrganizationVertical {
-    Default,
-    Music,
-}
+import {PaginatedResponse} from './types';
 
 export interface Organization {
     id: string;
     name: string;
     imageId: string;
     locale?: string;
-    vertical?: OrganizationVertical;
-}
-
-export interface PaginatedOrganizationResponse {
-    pagination: {
-        object_count: number;
-        page_number: number;
-        page_size: number;
-        page_count: number;
-        continuation: string;
-        has_more_items: boolean;
-    };
-    organizations: Organization[];
+    vertical?: 'Default' | 'Music';
 }
 
 /**
  * API for working with Organizations
  */
-export class OrganizationsApi extends BaseApi<PaginatedOrganizationResponse> {
+export class OrganizationsApi extends BaseApi<PaginatedResponse<Organization>> {
     getByUser(userId: string) {
         return this.request(`/users/${userId}/organizations/`);
     }

--- a/src/organizations.ts
+++ b/src/organizations.ts
@@ -13,6 +13,10 @@ export interface Organization {
  * API for working with Organizations
  */
 export class OrganizationsApi extends BaseApi<PaginatedResponse<Organization>> {
+    /**
+     * Get organizations based off a user id.
+     * @param {string} userId
+     */
     getByUser(userId: string) {
         return this.request(`/users/${userId}/organizations/`);
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,3 +31,17 @@ export interface JSONResponseData {
         [propName: string]: any;
     };
 }
+
+export interface Pagination {
+    objectCount: number;
+    pageNumber: number;
+    pageSize: number;
+    pageCount: number;
+    continuation: string;
+    hasMoreItems: boolean;
+}
+
+export interface PaginatedResponse<T> {
+    pagination: Pagination;
+    [key: string]: T[] | Pagination;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds helper methods for making calls to the organizations api. 

Currently this only adds the get organizations by user id call. 
<!--- Describe your changes in detail -->

<!--- Please include the phrase "BREAKING CHANGE:" here if your require a major release -->

<!--- Don't forget to note any issues here with "fixes #<issue number>" -->

## How Has This Been Tested?

Tests have been added to cover the new API call. 

<!--- Please describe in detail how you tested your changes. -->

<!--- For bug fixes, include regression unit tests that fail without the fix -->

<!--- For new features, include unit tests for the new functionality -->

## Screenshots (if appropriate):

## Checklist:

<!--- Please mark an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

*   [x] I have read the [**CONTRIBUTING** document](https://github.com/eventbrite/eventbrite-sdk-javascript/blob/master/CONTRIBUTING.md).
*   [x] I have updated the documentation accordingly.
*   [x] I have added tests to cover my changes.
*   [x] I have run `yarn validate` to ensure that tests, typescript and linting are all in order.
