### PR TITLE
Fixed types for TS 3.6.2

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -45,5 +45,5 @@ export interface Pagination {
 
 export interface PaginatedResponse<T> {
     pagination?: Pagination;
-    [key: string]: T[] | Pagination;
+    [key: string]: T[] | Pagination | undefined;
 }


### PR DESCRIPTION
The library doesn't work with recent versions of TS.
See #62 

## How Has This Been Tested?

`npx tsc --noEmit `

## Checklist:

*   [x] I have read the [**CONTRIBUTING** document](https://github.com/eventbrite/eventbrite-sdk-javascript/blob/master/CONTRIBUTING.md).
*   [ ] I have updated the documentation accordingly.
*   [ ] I have added tests to cover my changes.
*   [ ] I have run `yarn validate` to ensure that tests, typescript and linting are all in order.
